### PR TITLE
Add Item class

### DIFF
--- a/netherrack/netherrack.py
+++ b/netherrack/netherrack.py
@@ -92,6 +92,13 @@ class Sound:
     def compile(self):
         return {"item":{"id":"snd","data":{"sound": self.noise,"pitch": self.pitch,"vol": self.vol}},"slot":0}
 
+class Item:
+    def __init__(self, item_id, count=1, damage=0):
+        self.id, self.count, self.damage = item_id, count, damage
+
+    def compile(self):
+        return {"item":{"id":"item","data":{"item":'{DF_NBT:2230,id:"'+self.id+'",tag:{Damage:'+str(self.damage)+'},Count:'+str(self.count)+'}'}},"slot":0}
+
 class Line:
     def __init__(self, eventType, eventName):
         if eventType not in ("func", "process"):


### PR DESCRIPTION
Adds an Item class to represent items in game. Takes in the item_id as a string (like "minecraft:diamond_sword") and a quantity (defaults to 1). It also supports damage for items. I wanted to add enchantment support but I didn't know the best way to do that. I was thinking I could make an enchantment class but then it could be a top-level class or an inner class. I feel an inner class would be better but I'm not sure. Another option is a tuple that just contains the enchantment and the level. Since I couldn't decide, I didn't make it. Perhaps you could give advice on how to handle enchantments. I tested it and it works perfectly.